### PR TITLE
added lightweight possibility to add enchants into existing entries

### DIFF
--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListener.java
@@ -5,12 +5,16 @@ import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.*;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.enchantment.EnchantItemEvent;
+import org.bukkit.event.enchantment.PrepareItemEnchantEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.inventory.PrepareAnvilEvent;
+import org.bukkit.event.inventory.PrepareGrindstoneEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
@@ -33,6 +37,7 @@ import studio.magemonkey.divinity.hooks.external.FabledHook;
 import studio.magemonkey.divinity.manager.damage.DamageMeta;
 import studio.magemonkey.divinity.modules.list.arrows.ArrowManager;
 import studio.magemonkey.divinity.modules.list.arrows.ArrowManager.QArrow;
+import studio.magemonkey.divinity.modules.list.itemgenerator.ItemGeneratorManager;
 import studio.magemonkey.divinity.stats.EntityStats;
 import studio.magemonkey.divinity.stats.ProjectileStats;
 import studio.magemonkey.divinity.stats.items.ItemStats;
@@ -470,5 +475,25 @@ public class VanillaWrapperListener extends IListener<Divinity> {
                 defenses.put(defAtt, defense);
             });
         }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onAnvilUse(PrepareAnvilEvent e) {
+        ItemStack result = e.getResult();
+        if(result == null) return;
+        ItemGeneratorManager.updateGeneratorItemLore(result);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onEnchantingTable(PrepareItemEnchantEvent e) {
+        ItemStack result = e.getItem();
+        ItemGeneratorManager.updateGeneratorItemLore(result);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onGrindStone(PrepareGrindstoneEvent e) {
+        ItemStack result = e.getResult();
+        if(result == null) return;
+        ItemGeneratorManager.updateGeneratorItemLore(result);
     }
 }


### PR DESCRIPTION
Just one small thing I figured that was not possible yet..
If you add an enchanted book on a GeneratorItem, you will now get an updated "custom" lore from the '%ENCHANTS%' placeholder.

However, this is pretty lightweight and might give potential to have updates soon. Atm, there is no reliable way to detect on which position (including all other filled placeholders)  unless there is at least one enchantment available. If thats not the case, we simply add a '%ENCHANTS%'-placeholder at the end of a lore, if its not hidden by an Item-Flag.