### PR TITLE
Updated LevelledMobs Hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,13 +112,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.lokka30</groupId>
-            <artifactId>LevelledMobs</artifactId>
-            <version>4.0.0</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.elmakers.mine.bukkit</groupId>
             <artifactId>MagicAPI</artifactId>
             <version>10.2</version>

--- a/src/main/java/studio/magemonkey/divinity/hooks/external/LevelledMobsHK.java
+++ b/src/main/java/studio/magemonkey/divinity/hooks/external/LevelledMobsHK.java
@@ -1,7 +1,9 @@
 package studio.magemonkey.divinity.hooks.external;
 
-import me.lokka30.levelledmobs.LevelledMobs;
 import org.bukkit.Bukkit;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
@@ -10,11 +12,23 @@ import studio.magemonkey.codex.hooks.NHook;
 import studio.magemonkey.divinity.Divinity;
 import studio.magemonkey.divinity.hooks.HookMobLevel;
 
+import java.util.Objects;
+
 public class LevelledMobsHK extends NHook<Divinity> implements HookMobLevel {
 
     public LevelledMobsHK(@NotNull Divinity plugin) {
         super(plugin);
+
+        Plugin levelledMobsPlugin = Bukkit.getPluginManager().getPlugin("LevelledMobs");
+        levelledMobsIsInstalled = levelledMobsPlugin != null && levelledMobsPlugin.isEnabled();
+
+        if (levelledMobsIsInstalled){
+            key = new NamespacedKey(levelledMobsPlugin, "level");
+        }
     }
+
+    private final Boolean levelledMobsIsInstalled;
+    private NamespacedKey key;
 
     @Override
     @NotNull
@@ -25,12 +39,15 @@ public class LevelledMobsHK extends NHook<Divinity> implements HookMobLevel {
     @Override
     protected void shutdown() {}
 
+    public boolean hasLevelledMobsInstalled(){
+        return levelledMobsIsInstalled != null && levelledMobsIsInstalled;
+    }
+
     @Override
     public double getMobLevel(@NotNull Entity entity) {
-        if (!(entity instanceof LivingEntity)) return 0.0D;
-        if (Bukkit.getPluginManager().getPlugin("LevelledMobs") == null || !LevelledMobs.getInstance().isEnabled())
-            return 0.0D;
+        if (!(entity instanceof LivingEntity) || !hasLevelledMobsInstalled()) return 0.0D;
 
-        return LevelledMobs.getInstance().levelManager.getLevelOfMob((LivingEntity) entity);
+        Integer mobLevel = entity.getPersistentDataContainer().get(key, PersistentDataType.INTEGER);
+        return Objects.requireNonNullElse(mobLevel, 0);
     }
 }


### PR DESCRIPTION
Removed the dependency for the old version of LevelledMobs and updated the code so it works with versions 4.0 and later.