### PR TITLE
Attribute fix on itemgen

### DIFF
--- a/src/main/java/studio/magemonkey/divinity/modules/list/itemgenerator/editor/stats/StatListGUI.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/itemgenerator/editor/stats/StatListGUI.java
@@ -31,8 +31,16 @@ public class StatListGUI extends AbstractEditorGUI {
         if (section != null) {
             list.addAll(section.getKeys(false));
         }
+
+        this.slots.clear();
+
+        // Get from and to based on the page. I always can have 45 entries per page
+        int from = this.getPage() * 45;
+        int to = Math.min(from + 45, list.size());
+
         int i = 0;
-        for (String entry : list) {
+        for(int j = from; j < to; j++) {
+            String entry = list.get(j);
             i++;
             if (i % this.inventory.getSize() == 53) {
                 this.setSlot(i, getNextButton());

--- a/src/main/resources/modules/item_generator/items/common.yml
+++ b/src/main/resources/modules/item_generator/items/common.yml
@@ -274,7 +274,17 @@ generator:
       - '%FABLED_ATTRIBUTE_INTELLIGENCE%'
       - '%FABLED_ATTRIBUTE_DEXTERITY%'
       - '%FABLED_ATTRIBUTE_STRENGTH%'
-    list: {}
+    list:
+      #vitality:
+      #  chance: 20.0
+      #  scale-by-level: 1.025
+      #  min: 3.0
+      #  max: 6.25
+      #spirit:
+      #  chance: 20.0
+      #  scale-by-level: 1.025
+      #  min: 1.1
+      #  max: 1.25
   sockets:
     GEM:
       minimum: 0

--- a/src/main/resources/modules/item_generator/items/common.yml
+++ b/src/main/resources/modules/item_generator/items/common.yml
@@ -274,32 +274,7 @@ generator:
       - '%FABLED_ATTRIBUTE_INTELLIGENCE%'
       - '%FABLED_ATTRIBUTE_DEXTERITY%'
       - '%FABLED_ATTRIBUTE_STRENGTH%'
-    list:
-      vitality:
-        chance: 20.0
-        scale-by-level: 1.025
-        min: 3.0
-        max: 6.25
-      spirit:
-        chance: 20.0
-        scale-by-level: 1.025
-        min: 1.1
-        max: 1.25
-      intelligence:
-        chance: 10.0
-        scale-by-level: 1.025
-        min: 2.5
-        max: 4.0
-      dexterity:
-        chance: 10.0
-        scale-by-level: 1.025
-        min: 4.5
-        max: 7.5
-      strength:
-        chance: 10.0
-        scale-by-level: 1.025
-        min: 1.5
-        max: 7.0
+    list: {}
   sockets:
     GEM:
       minimum: 0


### PR DESCRIPTION
- Removed default fabled attributes from ItemGen template item due to incorrectness at some cases. The existent attributes will be added on the initial setup anyway
- Changes on the pagination to fix attribute dialogs on the correct pages