### PR TITLE
Full-Legacy support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <codex.version>1.1.1-R0.11-SNAPSHOT</codex.version>
-        <fabled.version>1.0.4-R0.56-SNAPSHOT</fabled.version>
+        <fabled.version>1.0.4-R0.63-SNAPSHOT</fabled.version>
     </properties>
 
     <repositories>

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -48,6 +48,7 @@ public class EngineCfg {
     public static boolean ATTRIBUTES_ALLOW_HOLD_REQUIREMENTS;
 
     public static boolean     ATTRIBUTES_DURABILITY_BREAK_ITEMS;
+    public static boolean     ATTRIBUTES_HIDE_FLAGS;
     public static boolean     ATTRIBUTES_DURABILITY_REDUCE_FOR_MOBS;
     public static Set<String> ATTRIBUTES_DURABILITY_REDUCE_FOR_SKILL_API;
 
@@ -56,6 +57,7 @@ public class EngineCfg {
     public static double  COMBAT_SHIELD_BLOCK_BONUS_DAMAGE_MOD;
     public static int     COMBAT_SHIELD_BLOCK_COOLDOWN;
     public static boolean LEGACY_COMBAT;
+    public static boolean FULL_LEGACY;
     public static boolean COMBAT_DISABLE_VANILLA_SWEEP;
     public static boolean COMBAT_REDUCE_PLAYER_HEALTH_BAR;
     public static boolean COMBAT_FISHING_HOOK_DO_DAMAGE;
@@ -177,6 +179,7 @@ public class EngineCfg {
         EngineCfg.ATTRIBUTES_EFFECTIVE_FOR_MOBS = cfg.getBoolean(path + "effective-for-mobs");
         EngineCfg.ATTRIBUTES_EFFECTIVE_IN_OFFHAND = cfg.getBoolean(path + "effective-in-offhand");
         EngineCfg.ATTRIBUTES_ALLOW_HOLD_REQUIREMENTS = cfg.getBoolean(path + "allow-hold-items-you-cant-use");
+        EngineCfg.ATTRIBUTES_HIDE_FLAGS = cfg.getBoolean(path + "hide-flags");
 
         path = "attributes.durability.";
         EngineCfg.ATTRIBUTES_DURABILITY_BREAK_ITEMS = cfg.getBoolean(path + "break-items-on-zero");

--- a/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
@@ -19,6 +19,7 @@ import studio.magemonkey.divinity.Divinity;
 import studio.magemonkey.divinity.api.event.DivinityDamageEvent;
 import studio.magemonkey.divinity.api.event.EntityDivinityItemPickupEvent;
 import studio.magemonkey.divinity.api.event.EntityEquipmentChangeEvent;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.modules.api.QModuleDrop;
 import studio.magemonkey.divinity.stats.EntityStats;
 import studio.magemonkey.divinity.stats.EntityStatsTask;
@@ -90,6 +91,7 @@ public class EntityManager extends IListener<Divinity> {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onStatsDeath(EntityDeathEvent e) {
+        if(EngineCfg.FULL_LEGACY) return;
         LivingEntity entity = e.getEntity();
         previousEquipment.remove(e.getEntity().getUniqueId());
         EntityStats.get(entity).handleDeath();
@@ -98,17 +100,20 @@ public class EntityManager extends IListener<Divinity> {
     // Clear stats on player exit
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onStatsQuit(PlayerQuitEvent e) {
+        if(EngineCfg.FULL_LEGACY) return;
         EntityStats.purge(e.getPlayer());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onStatsJoin(PlayerJoinEvent e) {
+        if(EngineCfg.FULL_LEGACY) return;
         EntityStats.get(e.getPlayer());
         this.pushToUpdate(e.getPlayer(), 1D);
     }
 
     @EventHandler
     public void quit(PlayerQuitEvent event) {
+        if(EngineCfg.FULL_LEGACY) return;
         previousEquipment.remove(event.getPlayer().getUniqueId());
     }
 
@@ -124,6 +129,7 @@ public class EntityManager extends IListener<Divinity> {
 
     @EventHandler(ignoreCancelled = true)
     public void onPickup(EntityPickupItemEvent e) {
+        if(EngineCfg.FULL_LEGACY) return;
         if (!ProjectileStats.isPickable(e.getItem())) {
             e.setCancelled(true);
         }
@@ -138,6 +144,7 @@ public class EntityManager extends IListener<Divinity> {
     }
 
     private final void pushToUpdate(@NotNull LivingEntity entity, double time) {
+        if(EngineCfg.FULL_LEGACY) return;
         EntityEquipment equip = new EntityEquipmentSnapshot(entity);
         previousEquipment.put(entity.getUniqueId(), equip);
         if (time <= 0D) {
@@ -153,6 +160,7 @@ public class EntityManager extends IListener<Divinity> {
     }
 
     private final void addDuplicatorFixer(@NotNull Entity entity) {
+        if(EngineCfg.FULL_LEGACY) return;
         entity.setMetadata(PACKET_DUPLICATOR_FIXER, new FixedMetadataValue(plugin, "fixed"));
     }
 

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/ListenerManager.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/ListenerManager.java
@@ -3,6 +3,8 @@ package studio.magemonkey.divinity.manager.listener;
 import org.jetbrains.annotations.NotNull;
 import studio.magemonkey.codex.manager.api.Loadable;
 import studio.magemonkey.divinity.Divinity;
+import studio.magemonkey.divinity.config.Config;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.hooks.HookListener;
 import studio.magemonkey.divinity.manager.listener.object.*;
 import studio.magemonkey.divinity.stats.items.ItemStats;
@@ -45,8 +47,13 @@ public class ListenerManager implements Loadable {
         this.lisDynamic = new DynamicStatListener(this.plugin);
         this.lisDynamic.registerListeners();
 
-        this.lisQuantum = new VanillaWrapperListener(this.plugin);
-        this.lisQuantum.registerListeners();
+        if(!EngineCfg.LEGACY_COMBAT) {
+            this.lisQuantum = new VanillaWrapperListener(this.plugin);
+            this.lisQuantum.registerListeners();
+            Divinity.getInstance().getLogger().info("Loaded " + this.lisQuantum.getClass().getSimpleName());
+        } else {
+            Divinity.getInstance().getLogger().info("Skipped " + VanillaWrapperListener.class.getSimpleName() + " due to legacy combat being enabled.");
+        }
 
         this.updater = new ItemUpdaterListener(this.plugin);
         this.updater.registerListeners();

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/DynamicStatListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/DynamicStatListener.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import studio.magemonkey.codex.manager.IListener;
 import studio.magemonkey.divinity.Divinity;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.stats.items.ItemStats;
 import studio.magemonkey.divinity.stats.items.api.DynamicStat;
 
@@ -27,6 +28,7 @@ public class DynamicStatListener extends IListener<Divinity> {
     }
 
     public static void updateItem(@Nullable Player p, @NotNull ItemStack item) {
+        if(EngineCfg.FULL_LEGACY) return;
         for (DynamicStat<?> dynamicStat : ItemStats.getDynamicStats()) {
             dynamicStat.updateItem(p, item);
         }
@@ -34,12 +36,14 @@ public class DynamicStatListener extends IListener<Divinity> {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onDrop(PlayerDropItemEvent e) {
+        if(EngineCfg.FULL_LEGACY) return;
         ItemStack item = e.getItemDrop().getItemStack();
         updateItem(null, item);
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onPick(EntityPickupItemEvent e) {
+        if(EngineCfg.FULL_LEGACY) return;
         LivingEntity entity = e.getEntity();
         if (!(entity instanceof Player)) return;
 
@@ -50,6 +54,7 @@ public class DynamicStatListener extends IListener<Divinity> {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onInvOpen(InventoryOpenEvent e) {
+        if(EngineCfg.FULL_LEGACY) return;
         List<ItemStack> list   = new ArrayList<>();
         Player          player = (Player) e.getPlayer();
 
@@ -64,6 +69,7 @@ public class DynamicStatListener extends IListener<Divinity> {
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onInvClose(InventoryCloseEvent e) {
+        if(EngineCfg.FULL_LEGACY) return;
         Player player = (Player) e.getPlayer();
 
         List<ItemStack> list = new ArrayList<>();

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/ItemUpdaterListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/ItemUpdaterListener.java
@@ -25,6 +25,7 @@ import studio.magemonkey.codex.api.meta.NBTAttribute;
 import studio.magemonkey.codex.manager.IListener;
 import studio.magemonkey.codex.util.DataUT;
 import studio.magemonkey.divinity.Divinity;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.stats.items.ItemStats;
 
 public class ItemUpdaterListener extends IListener<Divinity> {
@@ -93,6 +94,7 @@ public class ItemUpdaterListener extends IListener<Divinity> {
     }
 
     public void update(ItemStack item, @Nullable Player player) {
+        if(EngineCfg.LEGACY_COMBAT ||EngineCfg.FULL_LEGACY) return;
         if (item == null || item.getType() == Material.AIR) return;
 
         ItemType itemType = CodexEngine.get().getItemManager().getMainItemType(item);

--- a/src/main/java/studio/magemonkey/divinity/modules/ModuleItem.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/ModuleItem.java
@@ -1,6 +1,7 @@
 package studio.magemonkey.divinity.modules;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -8,6 +9,7 @@ import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.*;
@@ -135,15 +137,24 @@ public abstract class ModuleItem extends LoadableItem {
 
         this.attributes = new HashMap<>();
         for (String attr : cfg.getSection("attributes")) {
-            String[]          attrData     = cfg.getString("attributes." + attr, "").split(":");
-            double            value        = Double.parseDouble(attrData[0]);
-            String            operation    = attrData.length > 1 ? attrData[1] : "ADD_NUMBER";
-            NBTAttribute      nbtAttr      = NBTAttribute.valueOf(attr.toUpperCase());
-            AttributeModifier attrModifier = VersionManager.getCompat()
-                    .createAttributeModifier(nbtAttr, value, AttributeModifier.Operation.valueOf(operation));
+            String[]          attrData      = cfg.getString("attributes." + attr, "").split(":");
+            double            value         = Double.parseDouble(attrData[0]);
+            String            operation     = attrData.length > 1 ? attrData[1] : "ADD_NUMBER";
+            String            equipmentSlot = attrData.length > 2 ? attrData[2] : null;
+            NBTAttribute      nbtAttr       = NBTAttribute.valueOf(attr.toUpperCase());
+
+            // Check attribute through compat support
+            AttributeModifier attrModifier  = VersionManager.getCompat().createAttributeModifier(nbtAttr, value, AttributeModifier.Operation.valueOf(operation));
             if (attrModifier == null) {
                 Codex.warn("Invalid attribute provided: " + attr + " (" + cfg.getFile().getName() + ")");
                 continue;
+            }
+            // If everything was fine and equipmentslot != null, recreate the modifier including the equipment slot
+            if(equipmentSlot != null) {
+                EquipmentSlot slot = EquipmentSlot.valueOf(equipmentSlot.toUpperCase());
+                attrModifier = new AttributeModifier(attrModifier.getUniqueId(), attrModifier.getName(), attrModifier.getAmount(), attrModifier.getOperation(), slot);
+                // Debug
+                Bukkit.getLogger().info("Registered attribute " + nbtAttr.name() + " with value " + value + ", operation " + operation + " and equipment slot " + equipmentSlot + " for item " + this.getId());
             }
             this.attributes.put(nbtAttr.getAttribute(), attrModifier);
         }
@@ -277,6 +288,7 @@ public abstract class ModuleItem extends LoadableItem {
 
         for (Map.Entry<Attribute, AttributeModifier> attribute : this.attributes.entrySet()) {
             if (attribute != null) {
+                AttributeModifier mod = new AttributeModifier(attribute.getValue().getName(), attribute.getValue().getAmount(), attribute.getValue().getOperation());
                 meta.addAttributeModifier(attribute.getKey(), attribute.getValue());
             }
         }

--- a/src/main/java/studio/magemonkey/divinity/stats/EntityStats.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/EntityStats.java
@@ -435,6 +435,7 @@ public class EntityStats {
     }
 
     public void updateAll() {
+        if(EngineCfg.LEGACY_COMBAT) return;
         if (!EngineCfg.ATTRIBUTES_EFFECTIVE_FOR_MOBS && !this.isPlayer()) {
             return;
         }

--- a/src/main/java/studio/magemonkey/divinity/stats/items/ItemStats.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/items/ItemStats.java
@@ -308,7 +308,7 @@ public class ItemStats {
     // ----------------------------------------------------------------- //
 
     public static void updateVanillaAttributes(@NotNull ItemStack item, @Nullable Player player) {
-        //if(EngineCfg.LEGACY_COMBAT) return;
+        if(EngineCfg.FULL_LEGACY || EngineCfg.LEGACY_COMBAT) return;
 
         addAttribute(item, player, NBTAttribute.MAX_HEALTH, getStat(item, player, TypedStat.Type.MAX_HEALTH));
         addAttribute(item, player, NBTAttribute.MOVEMENT_SPEED, getStat(item, player, TypedStat.Type.MOVEMENT_SPEED));

--- a/src/main/java/studio/magemonkey/divinity/stats/items/ItemStats.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/items/ItemStats.java
@@ -19,6 +19,7 @@ import studio.magemonkey.codex.core.Version;
 import studio.magemonkey.codex.modules.IModule;
 import studio.magemonkey.codex.util.DataUT;
 import studio.magemonkey.divinity.Divinity;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.modules.api.QModuleDrop;
 import studio.magemonkey.divinity.stats.items.api.DuplicableItemLoreStat;
 import studio.magemonkey.divinity.stats.items.api.DynamicStat;
@@ -307,6 +308,8 @@ public class ItemStats {
     // ----------------------------------------------------------------- //
 
     public static void updateVanillaAttributes(@NotNull ItemStack item, @Nullable Player player) {
+        //if(EngineCfg.LEGACY_COMBAT) return;
+
         addAttribute(item, player, NBTAttribute.MAX_HEALTH, getStat(item, player, TypedStat.Type.MAX_HEALTH));
         addAttribute(item, player, NBTAttribute.MOVEMENT_SPEED, getStat(item, player, TypedStat.Type.MOVEMENT_SPEED));
         addAttribute(item, player, NBTAttribute.ATTACK_SPEED, getStat(item, player, TypedStat.Type.ATTACK_SPEED));
@@ -344,6 +347,7 @@ public class ItemStats {
                                      @Nullable Player player,
                                      @NotNull NBTAttribute att,
                                      double value) {
+        //if(EngineCfg.LEGACY_COMBAT) return;
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
 

--- a/src/main/resources/engine.yml
+++ b/src/main/resources/engine.yml
@@ -63,6 +63,8 @@ attributes:
   # When enabled, allows to hold in hand items with requirements that player don't meet.
   # Even when this is 'true', item attributes won't be applied to a player until he meet the requirements.
   allow-hold-items-you-cant-use: false
+  # When enabled, hides attributes and enchantments by default on all custom items.
+  hide-flags: true
 
 combat:
   # Whether to use the old combat formula for calculating defenses


### PR DESCRIPTION
added a 'full-legacy' configuration to avoid divinity modifying attributes, flags etc. if wished.

In my scenario we migrated our custom-item plugin to divinity. The combat hnadling and related stuff however had big impact and caused some bugs as wrong bow damage, sharpness, damage, no correct attribute behaviour, etc.

The `full-legacy` parameter is meant to just exclude all the handling if you are aware of the impact for your server and dont use divinity combat mechanics. It is by default set to `false`. I wasnt sure if I should merge it together with the existent `legacy-combat` param or not. But if you think it makes sense, I can change this without problems.