### PR TITLE
Fix vanilla durability bar sync and block vanilla mending

### DIFF
--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/ItemDurabilityListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/ItemDurabilityListener.java
@@ -13,7 +13,6 @@ import org.bukkit.event.player.PlayerItemDamageEvent;
 import org.bukkit.event.player.PlayerItemMendEvent;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.Damageable;
 import org.jetbrains.annotations.NotNull;
 import studio.magemonkey.codex.manager.IListener;
 import studio.magemonkey.codex.util.ItemUT;
@@ -39,6 +38,22 @@ public class ItemDurabilityListener extends IListener<Divinity> {
         if (ItemStats.hasStat(item, null, TypedStat.Type.DURABILITY) || this.duraStat.isUnbreakable(item)) {
             e.setCancelled(true);
         }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onMending(PlayerItemMendEvent e) {
+        ItemStack item = e.getItem();
+        if (!ItemStats.hasStat(item, null, TypedStat.Type.DURABILITY)) return;
+
+        e.setCancelled(true); // block vanilla mending
+
+        double[] dur = duraStat.getRaw(item);
+        if (dur == null || dur[1] <= 0 || dur[0] >= dur[1]) return; // full, unbreakable, or no data
+
+        int repairAmount = e.getRepairAmount();
+        double newCurrent = Math.min(dur[0] + repairAmount, dur[1]);
+        duraStat.add(item, new double[]{newCurrent, dur[1]}, -1);
+        duraStat.syncVanillaBar(item);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
@@ -112,50 +127,6 @@ public class ItemDurabilityListener extends IListener<Divinity> {
 
             if (!ItemUT.isAir(hoe) && hoe.getType().name().endsWith("_HOE")) {
                 this.duraStat.reduceDurability(player, hoe, 1);
-            }
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onMend(PlayerItemMendEvent e) {
-        ItemStack item = e.getItem();
-
-        if (!ItemStats.hasStat(item, null, TypedStat.Type.DURABILITY)) return;
-
-        double[] durability = duraStat.getRaw(item);
-        if (durability == null || duraStat.isUnbreakable(item)) return;
-
-        double current    = durability[0];
-        double max        = durability[1];
-        int    vanillaMax = item.getType().getMaxDurability();
-
-        if (vanillaMax <= 0) return;
-
-        int repair = e.getRepairAmount();
-        // Scale the repair amount to the durability max, so we can
-        // properly update the custom durability amount.
-        double customRepair = ((double) repair / vanillaMax) * max;
-        double newValue     = current + customRepair;
-
-        // Cap the durability at the max
-        if (newValue > max) {
-            newValue = max;
-        }
-
-        newValue = Math.round(newValue * 100.0) / 100.0;
-
-        duraStat.add(item, new double[]{newValue, max}, -1);
-        duraStat.syncVanillaBar(item, newValue, max);
-
-        e.setCancelled(true);
-
-        Damageable damageable = (Damageable) item.getItemMeta();
-        if (damageable != null) {
-            int vanillaDamage = damageable.getDamage();
-            if (vanillaDamage == 0) {
-                duraStat.add(item, new double[]{max, max}, -1);
-                duraStat.syncVanillaBar(item, max, max);
-                e.setCancelled(true);
             }
         }
     }

--- a/src/main/java/studio/magemonkey/divinity/modules/list/itemgenerator/generators/TypedStatGenerator.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/itemgenerator/generators/TypedStatGenerator.java
@@ -232,6 +232,7 @@ public class TypedStatGenerator extends AbstractAttributeGenerator {
                     } else if (stat instanceof DurabilityStat) {
                         DurabilityStat rStat = (DurabilityStat) stat;
                         rStat.add(item, new double[]{vFin, vFin}, -1);
+                        rStat.syncVanillaBar(item);
                     }
                 }
 

--- a/src/main/java/studio/magemonkey/divinity/modules/list/repair/RepairManager.java
+++ b/src/main/java/studio/magemonkey/divinity/modules/list/repair/RepairManager.java
@@ -211,6 +211,7 @@ public class RepairManager extends QModuleDrop<RepairItem> {
         double    max    = arr[1];
         ItemStack result = new ItemStack(target);
         this.duraStat.add(result, new double[]{max, max}, -1);
+        this.duraStat.syncVanillaBar(result);
 
         return result;
     }
@@ -382,6 +383,7 @@ public class RepairManager extends QModuleDrop<RepairItem> {
         durNow = (int) Math.min(durMax, durNow + durMax * 1D * (rPerc * 1D / 100D));
 
         this.duraStat.add(target, new double[]{durNow, durMax}, -1);
+        this.duraStat.syncVanillaBar(target);
         e.setCurrentItem(target);
 
         if (lost != null) {

--- a/src/main/java/studio/magemonkey/divinity/stats/items/attributes/stats/DurabilityStat.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/items/attributes/stats/DurabilityStat.java
@@ -24,8 +24,12 @@ import studio.magemonkey.divinity.stats.items.attributes.api.TypedStat;
 public class DurabilityStat extends ItemLoreStat<double[]> implements TypedStat {
     private double cap;
 
-    public DurabilityStat(@NotNull String name, @NotNull String format, double cap) {
-        super(TypedStat.Type.DURABILITY.name(),
+    public DurabilityStat(
+            @NotNull String name,
+            @NotNull String format,
+            double cap) {
+        super(
+                TypedStat.Type.DURABILITY.name(),
                 name,
                 format,
                 "%ITEM_STAT_" + TypedStat.Type.DURABILITY.name() + "%",
@@ -111,7 +115,9 @@ public class DurabilityStat extends ItemLoreStat<double[]> implements TypedStat 
         return durability != null && durability[0] == 0 && !EngineCfg.ATTRIBUTES_DURABILITY_BREAK_ITEMS;
     }
 
-    public boolean reduceDurability(@NotNull LivingEntity li, @NotNull ItemStack item, int amount) {
+    public boolean reduceDurability(
+            @NotNull LivingEntity li, @NotNull ItemStack item, int amount) {
+
         if (!(li instanceof Player) && !EngineCfg.ATTRIBUTES_DURABILITY_REDUCE_FOR_MOBS) return false;
         if (this.isUnbreakable(item)) return false;
 
@@ -151,13 +157,33 @@ public class DurabilityStat extends ItemLoreStat<double[]> implements TypedStat 
         }
 
         boolean result = this.add(item, new double[]{lose, max}, -1);
+        if (result) syncVanillaBar(item);
+        return result;
+    }
 
-        if (result) {
-            syncVanillaBar(item, lose, max);
+    /**
+     * Synchronizes the vanilla durability bar to reflect Divinity custom durability as a percentage.
+     * Safeguard: if vanilla bar would show 100% but Divinity dura is not max, vanilla bar shows at least 1 damage.
+     */
+    public void syncVanillaBar(@NotNull ItemStack item) {
+        double[] dur = this.getRaw(item);
+        if (dur == null || dur[1] <= 0) return;
+        if (!(item.getItemMeta() instanceof Damageable)) return;
+
+        double percent = dur[0] / dur[1];
+        int maxVanilla = item.getType().getMaxDurability();
+        if (maxVanilla <= 0) return;
+
+        int vanillaDamage = (int) Math.round(maxVanilla * (1.0 - percent));
+
+        // Safeguard: don't show full vanilla bar when divinity dura is not max
+        if (vanillaDamage == 0 && dur[0] < dur[1]) {
+            vanillaDamage = 1;
         }
 
-        return result;
-
+        Damageable meta = (Damageable) item.getItemMeta();
+        meta.setDamage(vanillaDamage);
+        item.setItemMeta((ItemMeta) meta);
     }
 
     @Override
@@ -165,30 +191,4 @@ public class DurabilityStat extends ItemLoreStat<double[]> implements TypedStat 
     public String formatValue(@NotNull ItemStack item, double[] values) {
         return EngineCfg.getDurabilityFormat((int) values[0], (int) values[1]);
     }
-
-    /**
-     * Syncs the durability stat with the vanilla durability bar. Should be called after any change to the durability stat.
-     * Note: This method assumes that the durability stat is already updated with the new values before calling it.
-     *
-     * @param item the item that needs updating
-     * @param current the current durability value on the item
-     * @param maxCustom the max value possible to be set for the item
-     */
-    public void syncVanillaBar(@NotNull ItemStack item, double current, double maxCustom) {
-        ItemMeta meta = item.getItemMeta();
-        if (!(meta instanceof Damageable)) return;
-
-        Damageable damageable = (Damageable) meta;
-
-        int maxVanilla = item.getType().getMaxDurability();
-        if (maxVanilla <= 0) return;
-
-        double percent       = current / maxCustom;
-        // Scale the vanilla value to the custom percentage
-        int    vanillaDamage = (int) ((1.0 - percent) * maxVanilla);
-
-        damageable.setDamage(vanillaDamage);
-        item.setItemMeta(damageable);
-    }
-
 }

--- a/src/main/java/studio/magemonkey/divinity/stats/items/attributes/stats/DurabilityStat.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/items/attributes/stats/DurabilityStat.java
@@ -162,6 +162,18 @@ public class DurabilityStat extends ItemLoreStat<double[]> implements TypedStat 
     }
 
     /**
+     * @deprecated the current/max arguments are no longer used — the stat now reads its own
+     *             values directly, since deriving the vanilla-bar percentage from caller-supplied
+     *             values (rather than the stat's own state) was the source of the sync bug this
+     *             replaced. Kept for source/binary compatibility with existing callers; use
+     *             {@link #syncVanillaBar(ItemStack)} instead.
+     */
+    @Deprecated
+    public void syncVanillaBar(@NotNull ItemStack item, double current, double maxCustom) {
+        syncVanillaBar(item);
+    }
+
+    /**
      * Synchronizes the vanilla durability bar to reflect Divinity custom durability as a percentage.
      * Safeguard: if vanilla bar would show 100% but Divinity dura is not max, vanilla bar shows at least 1 damage.
      */


### PR DESCRIPTION
Split out of #320 (piece 2/12, independent).

The vanilla durability bar was scaled incorrectly against custom durability, and vanilla mending bypassed the custom durability stat entirely. `syncVanillaBar()` now derives the displayed damage directly from the stat's own current/max percentage (with a safeguard so the bar never shows fully-repaired when custom durability isn't actually at max), and `PlayerItemMendEvent` is cancelled in favor of applying the repair through the custom durability stat.

## Backward compatibility
`syncVanillaBar` changed from `(item, current, maxCustom)` to `(item)`. Kept the old 3-arg signature as a `@Deprecated` overload that delegates to the corrected version, so any addon compiled against it keeps working (and gets the bugfix) without needing to update immediately.