### PR TITLE
Animate success bar fully green at 100% chance

### DIFF
--- a/src/main/java/studio/magemonkey/divinity/manager/interactions/api/AnimatedSuccessBar.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/interactions/api/AnimatedSuccessBar.java
@@ -147,9 +147,11 @@ public class AnimatedSuccessBar extends ICustomInteraction {
 
         Task() {
             super(AnimatedSuccessBar.this.plugin, AnimatedSuccessBar.this.fillInterval, true);
-            int calculatedResult = Math.round(Rnd.get(true));
-            int iterations       = (int) Math.ceil(100D / fillAmount);
-            // Map the iteration to the relative success for the result
+            int iterations = (int) Math.ceil(100D / fillAmount);
+            // At 100% chance the bar should animate fully green — no red segments
+            int calculatedResult = (chance >= 100)
+                    ? iterations * fillAmount + 1
+                    : Math.round(Rnd.get(true));
             for (int i = 0; i < iterations; i++) {
                 mappedResult.add(i * fillAmount < calculatedResult);
             }


### PR DESCRIPTION
Split out of #320 (piece 6/12, independent).

At exactly 100% chance the bar still rolled a random fill result, so it could visually show red segments despite the action being guaranteed to succeed. Forces the full bar green when chance >= 100.

## Backward compatibility
None applicable — purely visual/cosmetic, no data or API surface involved.