### PR TITLE
VanillaOnly Stat support & Fixes on resistance and absorption mechanics

### DIFF
--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -430,7 +430,7 @@ public class EngineCfg {
                 StringUT.color(cfg.getString(path, "&7%attrPre%&3%name%&7%attrPost%"));
 
 
-        path = "legacy.vanilla-entity-stats";
+        path = "vanilla-only.entity-stats";
         cfg.addMissing(path, false);
         EngineCfg.VANILLA_ONLY_ENTITY_STATS = cfg.getBoolean(path, false);
         path = "vanilla-only.item-stats";

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -435,7 +435,7 @@ public class EngineCfg {
         EngineCfg.VANILLA_ONLY_ENTITY_STATS = cfg.getBoolean(path, false);
         path = "legacy.vanilla-item-stats";
         cfg.addMissing(path, false);
-        EngineCfg.LEGACY_VANILLA_ITEM_STATS = cfg.getBoolean(path, false);
+        EngineCfg.VANILLA_ONLY_ITEM_STATS = cfg.getBoolean(path, false);
 
         cfg.saveChanges();
     }

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -175,11 +175,11 @@ public class EngineCfg {
 
         // A T T R I B U T E S //
         path = "attributes.";
+        cfg.addMissing(path + "hide-flags", true);
         EngineCfg.ATTRIBUTES_EFFECTIVE_FOR_MOBS = cfg.getBoolean(path + "effective-for-mobs");
         EngineCfg.ATTRIBUTES_EFFECTIVE_IN_OFFHAND = cfg.getBoolean(path + "effective-in-offhand");
         EngineCfg.ATTRIBUTES_ALLOW_HOLD_REQUIREMENTS = cfg.getBoolean(path + "allow-hold-items-you-cant-use");
         EngineCfg.ATTRIBUTES_HIDE_FLAGS = cfg.getBoolean(path + "hide-flags");
-
         path = "attributes.durability.";
         EngineCfg.ATTRIBUTES_DURABILITY_BREAK_ITEMS = cfg.getBoolean(path + "break-items-on-zero");
         EngineCfg.ATTRIBUTES_DURABILITY_REDUCE_FOR_MOBS = cfg.getBoolean(path + "effective-for.mobs");

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -114,6 +114,9 @@ public class EngineCfg {
 
     public static String LORE_STYLE_FABLED_ATTRIBUTE_FORMAT;
 
+    public static boolean LEGACY_VANILLA_ENTITY_STATS;
+    public static boolean LEGACY_VANILLA_ITEM_STATS;
+
     public void setup() {
         this.plugin.info("Loading engine configuration...");
 
@@ -425,6 +428,14 @@ public class EngineCfg {
         cfg.addMissing(path, "&7%attrPre%&3%name%&7%attrPost%");
         EngineCfg.LORE_STYLE_FABLED_ATTRIBUTE_FORMAT =
                 StringUT.color(cfg.getString(path, "&7%attrPre%&3%name%&7%attrPost%"));
+
+
+        path = "legacy.vanilla-entity-stats";
+        cfg.addMissing(path, false);
+        EngineCfg.LEGACY_VANILLA_ENTITY_STATS = cfg.getBoolean(path, false);
+        path = "legacy.vanilla-item-stats";
+        cfg.addMissing(path, false);
+        EngineCfg.LEGACY_VANILLA_ITEM_STATS = cfg.getBoolean(path, false);
 
         cfg.saveChanges();
     }

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -63,6 +63,7 @@ public class EngineCfg {
     public static boolean COMBAT_BOWS_DO_FULL_MELEE_DAMAGE;
     public static double  COMBAT_DAMAGE_MODIFIER_FOR_COOLDOWN;
     public static double  COMBAT_MAX_GET_TARGET_DISTANCE;
+    public static boolean VANILLA_ONLY_DAMAGE_HANDLING;
 
     public static String LORE_CHAR_PERCENT;
     public static String LORE_CHAR_NEGATIVE;
@@ -436,6 +437,9 @@ public class EngineCfg {
         path = "vanilla-only.item-stats";
         cfg.addMissing(path, false);
         EngineCfg.VANILLA_ONLY_ITEM_STATS = cfg.getBoolean(path, false);
+        path = "vanilla-only.damage-handling";
+        cfg.addMissing(path, false);
+        EngineCfg.VANILLA_ONLY_DAMAGE_HANDLING = cfg.getBoolean(path, false);
 
         cfg.saveChanges();
     }

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -432,7 +432,7 @@ public class EngineCfg {
 
         path = "legacy.vanilla-entity-stats";
         cfg.addMissing(path, false);
-        EngineCfg.LEGACY_VANILLA_ENTITY_STATS = cfg.getBoolean(path, false);
+        EngineCfg.VANILLA_ONLY_ENTITY_STATS = cfg.getBoolean(path, false);
         path = "legacy.vanilla-item-stats";
         cfg.addMissing(path, false);
         EngineCfg.LEGACY_VANILLA_ITEM_STATS = cfg.getBoolean(path, false);

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -114,7 +114,7 @@ public class EngineCfg {
 
     public static String LORE_STYLE_FABLED_ATTRIBUTE_FORMAT;
 
-    public static boolean LEGACY_VANILLA_ENTITY_STATS;
+    public static boolean VANILLA_ONLY_ENTITY_STATS;
     public static boolean LEGACY_VANILLA_ITEM_STATS;
 
     public void setup() {

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -433,7 +433,7 @@ public class EngineCfg {
         path = "legacy.vanilla-entity-stats";
         cfg.addMissing(path, false);
         EngineCfg.VANILLA_ONLY_ENTITY_STATS = cfg.getBoolean(path, false);
-        path = "legacy.vanilla-item-stats";
+        path = "vanilla-only.item-stats";
         cfg.addMissing(path, false);
         EngineCfg.VANILLA_ONLY_ITEM_STATS = cfg.getBoolean(path, false);
 

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -115,7 +115,7 @@ public class EngineCfg {
     public static String LORE_STYLE_FABLED_ATTRIBUTE_FORMAT;
 
     public static boolean VANILLA_ONLY_ENTITY_STATS;
-    public static boolean LEGACY_VANILLA_ITEM_STATS;
+    public static boolean VANILLA_ONLY_ITEM_STATS;
 
     public void setup() {
         this.plugin.info("Loading engine configuration...");

--- a/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
+++ b/src/main/java/studio/magemonkey/divinity/config/EngineCfg.java
@@ -46,6 +46,7 @@ public class EngineCfg {
     public static boolean ATTRIBUTES_EFFECTIVE_FOR_MOBS;
     public static boolean ATTRIBUTES_EFFECTIVE_IN_OFFHAND;
     public static boolean ATTRIBUTES_ALLOW_HOLD_REQUIREMENTS;
+    public static boolean ATTRIBUTES_HIDE_FLAGS;
 
     public static boolean     ATTRIBUTES_DURABILITY_BREAK_ITEMS;
     public static boolean     ATTRIBUTES_DURABILITY_REDUCE_FOR_MOBS;
@@ -177,6 +178,7 @@ public class EngineCfg {
         EngineCfg.ATTRIBUTES_EFFECTIVE_FOR_MOBS = cfg.getBoolean(path + "effective-for-mobs");
         EngineCfg.ATTRIBUTES_EFFECTIVE_IN_OFFHAND = cfg.getBoolean(path + "effective-in-offhand");
         EngineCfg.ATTRIBUTES_ALLOW_HOLD_REQUIREMENTS = cfg.getBoolean(path + "allow-hold-items-you-cant-use");
+        EngineCfg.ATTRIBUTES_HIDE_FLAGS = cfg.getBoolean(path + "hide-flags");
 
         path = "attributes.durability.";
         EngineCfg.ATTRIBUTES_DURABILITY_BREAK_ITEMS = cfg.getBoolean(path + "break-items-on-zero");

--- a/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
@@ -2,6 +2,7 @@ package studio.magemonkey.divinity.manager;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -160,6 +161,23 @@ public class EntityManager extends IListener<Divinity> {
         }.runTask(Divinity.getInstance());
     }
 
+    private void updateVanillaItemAttributes(@NotNull LivingEntity entity) {
+        if (EngineCfg.LEGACY_VANILLA_ITEM_STATS) return;
+
+        EntityEquipment equipment = entity.getEquipment();
+        if (equipment == null) return;
+
+        for (ItemStack item : equipment.getArmorContents()) {
+            if (item != null) ItemStats.updateVanillaAttributes(item, entity instanceof Player ? (Player) entity : null);
+        }
+
+        ItemStack main = equipment.getItemInMainHand();
+        if (main != null) ItemStats.updateVanillaAttributes(main, entity instanceof Player ? (Player) entity : null);
+
+        ItemStack off = equipment.getItemInOffHand();
+        if (off != null) ItemStats.updateVanillaAttributes(off, entity instanceof Player ? (Player) entity : null);
+    }
+
     private final void addDuplicatorFixer(@NotNull Entity entity) {
         if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         entity.setMetadata(PACKET_DUPLICATOR_FIXER, new FixedMetadataValue(plugin, "fixed"));
@@ -206,6 +224,7 @@ public class EntityManager extends IListener<Divinity> {
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void onEntityUpdateEquipmentChange(EntityEquipmentChangeEvent e) {
+        this.updateVanillaItemAttributes(e.getEntity());
         this.pushToUpdate(e.getEntity(), 0.5D);
     }
 }

--- a/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
@@ -92,7 +92,7 @@ public class EntityManager extends IListener<Divinity> {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onStatsDeath(EntityDeathEvent e) {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         LivingEntity entity = e.getEntity();
         previousEquipment.remove(e.getEntity().getUniqueId());
         EntityStats.get(entity).handleDeath();

--- a/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
@@ -19,6 +19,7 @@ import studio.magemonkey.divinity.Divinity;
 import studio.magemonkey.divinity.api.event.DivinityDamageEvent;
 import studio.magemonkey.divinity.api.event.EntityDivinityItemPickupEvent;
 import studio.magemonkey.divinity.api.event.EntityEquipmentChangeEvent;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.modules.api.QModuleDrop;
 import studio.magemonkey.divinity.stats.EntityStats;
 import studio.magemonkey.divinity.stats.EntityStatsTask;
@@ -90,6 +91,7 @@ public class EntityManager extends IListener<Divinity> {
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onStatsDeath(EntityDeathEvent e) {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         LivingEntity entity = e.getEntity();
         previousEquipment.remove(e.getEntity().getUniqueId());
         EntityStats.get(entity).handleDeath();
@@ -98,22 +100,26 @@ public class EntityManager extends IListener<Divinity> {
     // Clear stats on player exit
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onStatsQuit(PlayerQuitEvent e) {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         EntityStats.purge(e.getPlayer());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onStatsJoin(PlayerJoinEvent e) {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         EntityStats.get(e.getPlayer());
         this.pushToUpdate(e.getPlayer(), 1D);
     }
 
     @EventHandler
     public void quit(PlayerQuitEvent event) {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         previousEquipment.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onStatsRegen(EntityRegainHealthEvent e) {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         Entity e1 = e.getEntity();
         if (!(e1 instanceof LivingEntity)) return;
 
@@ -124,6 +130,7 @@ public class EntityManager extends IListener<Divinity> {
 
     @EventHandler(ignoreCancelled = true)
     public void onPickup(EntityPickupItemEvent e) {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         if (!ProjectileStats.isPickable(e.getItem())) {
             e.setCancelled(true);
         }
@@ -138,6 +145,7 @@ public class EntityManager extends IListener<Divinity> {
     }
 
     private final void pushToUpdate(@NotNull LivingEntity entity, double time) {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         EntityEquipment equip = new EntityEquipmentSnapshot(entity);
         previousEquipment.put(entity.getUniqueId(), equip);
         if (time <= 0D) {
@@ -153,6 +161,7 @@ public class EntityManager extends IListener<Divinity> {
     }
 
     private final void addDuplicatorFixer(@NotNull Entity entity) {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         entity.setMetadata(PACKET_DUPLICATOR_FIXER, new FixedMetadataValue(plugin, "fixed"));
     }
 

--- a/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/EntityManager.java
@@ -101,26 +101,26 @@ public class EntityManager extends IListener<Divinity> {
     // Clear stats on player exit
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onStatsQuit(PlayerQuitEvent e) {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         EntityStats.purge(e.getPlayer());
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onStatsJoin(PlayerJoinEvent e) {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         EntityStats.get(e.getPlayer());
         this.pushToUpdate(e.getPlayer(), 1D);
     }
 
     @EventHandler
     public void quit(PlayerQuitEvent event) {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         previousEquipment.remove(event.getPlayer().getUniqueId());
     }
 
     @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
     public void onStatsRegen(EntityRegainHealthEvent e) {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         Entity e1 = e.getEntity();
         if (!(e1 instanceof LivingEntity)) return;
 
@@ -131,7 +131,7 @@ public class EntityManager extends IListener<Divinity> {
 
     @EventHandler(ignoreCancelled = true)
     public void onPickup(EntityPickupItemEvent e) {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         if (!ProjectileStats.isPickable(e.getItem())) {
             e.setCancelled(true);
         }
@@ -146,7 +146,7 @@ public class EntityManager extends IListener<Divinity> {
     }
 
     private final void pushToUpdate(@NotNull LivingEntity entity, double time) {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         EntityEquipment equip = new EntityEquipmentSnapshot(entity);
         previousEquipment.put(entity.getUniqueId(), equip);
         if (time <= 0D) {
@@ -162,7 +162,7 @@ public class EntityManager extends IListener<Divinity> {
     }
 
     private void updateVanillaItemAttributes(@NotNull LivingEntity entity) {
-        if (EngineCfg.LEGACY_VANILLA_ITEM_STATS) return;
+        if (EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
 
         EntityEquipment equipment = entity.getEquipment();
         if (equipment == null) return;
@@ -179,7 +179,7 @@ public class EntityManager extends IListener<Divinity> {
     }
 
     private final void addDuplicatorFixer(@NotNull Entity entity) {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         entity.setMetadata(PACKET_DUPLICATOR_FIXER, new FixedMetadataValue(plugin, "fixed"));
     }
 

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/DynamicStatListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/DynamicStatListener.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import studio.magemonkey.codex.manager.IListener;
 import studio.magemonkey.divinity.Divinity;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.stats.items.ItemStats;
 import studio.magemonkey.divinity.stats.items.api.DynamicStat;
 
@@ -27,6 +28,7 @@ public class DynamicStatListener extends IListener<Divinity> {
     }
 
     public static void updateItem(@Nullable Player p, @NotNull ItemStack item) {
+        if(EngineCfg.LEGACY_VANILLA_ITEM_STATS) return;
         for (DynamicStat<?> dynamicStat : ItemStats.getDynamicStats()) {
             dynamicStat.updateItem(p, item);
         }

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/DynamicStatListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/DynamicStatListener.java
@@ -28,7 +28,7 @@ public class DynamicStatListener extends IListener<Divinity> {
     }
 
     public static void updateItem(@Nullable Player p, @NotNull ItemStack item) {
-        if(EngineCfg.LEGACY_VANILLA_ITEM_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ITEM_STATS) return;
         for (DynamicStat<?> dynamicStat : ItemStats.getDynamicStats()) {
             dynamicStat.updateItem(p, item);
         }

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/ItemUpdaterListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/ItemUpdaterListener.java
@@ -25,8 +25,11 @@ import studio.magemonkey.codex.api.meta.NBTAttribute;
 import studio.magemonkey.codex.manager.IListener;
 import studio.magemonkey.codex.util.DataUT;
 import studio.magemonkey.divinity.Divinity;
+import studio.magemonkey.divinity.api.DivinityAPI;
 import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.stats.items.ItemStats;
+
+import java.util.Objects;
 
 public class ItemUpdaterListener extends IListener<Divinity> {
 
@@ -109,6 +112,18 @@ public class ItemUpdaterListener extends IListener<Divinity> {
                 meta.removeItemFlags(ItemFlag.HIDE_ATTRIBUTES);
             } else if(EngineCfg.ATTRIBUTES_HIDE_FLAGS) {
                 meta.addItemFlags(ItemFlag.values());
+            } else {
+                // Reapply only the required flags on from a copied item
+                try {
+                    var itemCopy = Objects.requireNonNull(CodexEngine.get().getItemManager().getMainItemType(item)).create();
+                    if(itemCopy == null) return;
+                    var itemCopyMeta = itemCopy.getItemMeta();
+                    if(itemCopyMeta == null) return;
+                    meta.removeItemFlags(ItemFlag.values());
+                    meta.addItemFlags(itemCopyMeta.getItemFlags().toArray(new ItemFlag[0]));
+                } catch (Exception e) {
+                    return;
+                }
             }
             item.setItemMeta(meta);
         }

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/ItemUpdaterListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/ItemUpdaterListener.java
@@ -25,6 +25,7 @@ import studio.magemonkey.codex.api.meta.NBTAttribute;
 import studio.magemonkey.codex.manager.IListener;
 import studio.magemonkey.codex.util.DataUT;
 import studio.magemonkey.divinity.Divinity;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.stats.items.ItemStats;
 
 public class ItemUpdaterListener extends IListener<Divinity> {
@@ -106,7 +107,7 @@ public class ItemUpdaterListener extends IListener<Divinity> {
             if (fixed) {
                 DataUT.removeData(item, key);
                 meta.removeItemFlags(ItemFlag.HIDE_ATTRIBUTES);
-            } else {
+            } else if(EngineCfg.ATTRIBUTES_HIDE_FLAGS) {
                 meta.addItemFlags(ItemFlag.values());
             }
             item.setItemMeta(meta);

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListener.java
@@ -376,16 +376,23 @@ public class VanillaWrapperListener extends IListener<Divinity> {
         // +----------------------------------------------------+
 //        Divinity.getInstance().info("Damage Final Check: " + e.getFinalDamage() + "/" + e.getDamage());
         if (e.getFinalDamage() != e.getDamage()) {
-            double absorption = Math.min(e.getDamage(), victim.getAbsorptionAmount());
+            double damageBeforeAbsorption = e.getDamage();
+            if (e.isApplicable(DamageModifier.RESISTANCE)) {
+                damageBeforeAbsorption += e.getDamage(DamageModifier.RESISTANCE);
+            }
+            double absorption = Math.min(Math.max(0D, damageBeforeAbsorption), victim.getAbsorptionAmount());
             for (DamageModifier dmgModifier : DamageModifier.values()) {
-                if (dmgModifier == DamageModifier.ABSORPTION) continue;
                 if (e.isApplicable(dmgModifier)) {
                     if (dmgModifier == DamageModifier.BASE) {
 //                        Divinity.getInstance().info("FINAL - " + dmgModifier.name() + ": " + e.getDamage());
-                        e.setDamage(dmgModifier, e.getDamage() - absorption);
+                        e.setDamage(dmgModifier, e.getDamage());
                     } else if (dmgModifier == DamageModifier.ABSORPTION) {
-                        e.setDamage(dmgModifier, absorption);
-                    } else if (!dmgModifier.name().equals("INVULNERABILITY_REDUCTION"))
+                        // Bukkit represents absorption as a negative damage modifier.
+                        // Keep it in the final damage calculation instead of subtracting
+                        // it from BASE (which caused the absorption modifier to be applied
+                        // twice or not at all depending on the damage source).
+                        e.setDamage(dmgModifier, -absorption);
+                    } else if (!dmgModifier.name().equals("INVULNERABILITY_REDUCTION") && !dmgModifier.name().equals("RESISTANCE"))
                         e.setDamage(dmgModifier, 0); // Fix
                 }
             }

--- a/src/main/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListener.java
+++ b/src/main/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListener.java
@@ -139,6 +139,8 @@ public class VanillaWrapperListener extends IListener<Divinity> {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onVanillaDamage(EntityDamageEvent e) {
+        if (EngineCfg.VANILLA_ONLY_DAMAGE_HANDLING) return;
+
         boolean isEde = e instanceof EntityDamageByEntityEvent;
         if (isEde && plugin.getPluginManager().isPluginEnabled("Fabled")) {
             EntityDamageByEntityEvent ede        = (EntityDamageByEntityEvent) e;

--- a/src/main/java/studio/magemonkey/divinity/stats/EntityStats.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/EntityStats.java
@@ -438,6 +438,7 @@ public class EntityStats {
     }
 
     public void updateAll() {
+        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
         if (!EngineCfg.ATTRIBUTES_EFFECTIVE_FOR_MOBS && !this.isPlayer()) {
             return;
         }

--- a/src/main/java/studio/magemonkey/divinity/stats/EntityStats.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/EntityStats.java
@@ -438,7 +438,7 @@ public class EntityStats {
     }
 
     public void updateAll() {
-        if(EngineCfg.LEGACY_VANILLA_ENTITY_STATS) return;
+        if(EngineCfg.VANILLA_ONLY_ENTITY_STATS) return;
         if (!EngineCfg.ATTRIBUTES_EFFECTIVE_FOR_MOBS && !this.isPlayer()) {
             return;
         }

--- a/src/main/java/studio/magemonkey/divinity/stats/items/ItemStats.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/items/ItemStats.java
@@ -309,7 +309,7 @@ public class ItemStats {
     // ----------------------------------------------------------------- //
 
     public static void updateVanillaAttributes(@NotNull ItemStack item, @Nullable Player player) {
-        if (EngineCfg.LEGACY_VANILLA_ITEM_STATS) return;
+        if (EngineCfg.VANILLA_ONLY_ITEM_STATS) return;
 
         addAttribute(item, player, NBTAttribute.MAX_HEALTH, getStat(item, player, TypedStat.Type.MAX_HEALTH));
         addAttribute(item, player, NBTAttribute.MOVEMENT_SPEED, getStat(item, player, TypedStat.Type.MOVEMENT_SPEED));

--- a/src/main/java/studio/magemonkey/divinity/stats/items/ItemStats.java
+++ b/src/main/java/studio/magemonkey/divinity/stats/items/ItemStats.java
@@ -20,6 +20,7 @@ import studio.magemonkey.codex.core.Version;
 import studio.magemonkey.codex.modules.IModule;
 import studio.magemonkey.codex.util.DataUT;
 import studio.magemonkey.divinity.Divinity;
+import studio.magemonkey.divinity.config.EngineCfg;
 import studio.magemonkey.divinity.modules.api.QModuleDrop;
 import studio.magemonkey.divinity.stats.items.api.DuplicableItemLoreStat;
 import studio.magemonkey.divinity.stats.items.api.DynamicStat;
@@ -308,6 +309,8 @@ public class ItemStats {
     // ----------------------------------------------------------------- //
 
     public static void updateVanillaAttributes(@NotNull ItemStack item, @Nullable Player player) {
+        if (EngineCfg.LEGACY_VANILLA_ITEM_STATS) return;
+
         addAttribute(item, player, NBTAttribute.MAX_HEALTH, getStat(item, player, TypedStat.Type.MAX_HEALTH));
         addAttribute(item, player, NBTAttribute.MOVEMENT_SPEED, getStat(item, player, TypedStat.Type.MOVEMENT_SPEED));
         addAttribute(item, player, NBTAttribute.ATTACK_SPEED, getStat(item, player, TypedStat.Type.ATTACK_SPEED));

--- a/src/main/resources/engine.yml
+++ b/src/main/resources/engine.yml
@@ -63,6 +63,8 @@ attributes:
   # When enabled, allows to hold in hand items with requirements that player don't meet.
   # Even when this is 'true', item attributes won't be applied to a player until he meet the requirements.
   allow-hold-items-you-cant-use: false
+  # When enabled, hides attributes and enchantments by default on all custom items.
+  hide-flags: true
 
 combat:
   # Whether to use the old combat formula for calculating defenses

--- a/src/main/resources/engine.yml
+++ b/src/main/resources/engine.yml
@@ -232,3 +232,11 @@ lore:
           main: '&c▸ %name% %value%'
           max-roman: 10
       fabled-attribute-format: '&7%attrPre%&3%name%&7%attrPost%'
+
+vanilla-only:
+  # When enabled, Divinity will not replace vanilla entity-stat handling.
+  entity-stats: false
+  # When enabled, Divinity will not add generated vanilla item attributes.
+  item-stats: false
+  # When enabled, Divinity leaves damage events to Minecraft's vanilla handling.
+  damage-handling: false

--- a/src/test/java/studio/magemonkey/divinity/manager/EntityManagerTest.java
+++ b/src/test/java/studio/magemonkey/divinity/manager/EntityManagerTest.java
@@ -21,12 +21,12 @@ class EntityManagerTest extends MockedTest {
 
     @AfterEach
     void resetFlag() {
-        EngineCfg.LEGACY_VANILLA_ENTITY_STATS = false;
+        EngineCfg.VANILLA_ONLY_ENTITY_STATS = false;
     }
 
     @Test
     void entityStatsHandlingAppliesDuplicatorFixerByDefault() {
-        EngineCfg.LEGACY_VANILLA_ENTITY_STATS = false;
+        EngineCfg.VANILLA_ONLY_ENTITY_STATS = false;
 
         server.getPluginManager().callEvent(new PlayerToggleSprintEvent(player, true));
 
@@ -36,7 +36,7 @@ class EntityManagerTest extends MockedTest {
 
     @Test
     void legacyVanillaEntityStatsSkipsDuplicatorFixer() {
-        EngineCfg.LEGACY_VANILLA_ENTITY_STATS = true;
+        EngineCfg.VANILLA_ONLY_ENTITY_STATS = true;
 
         server.getPluginManager().callEvent(new PlayerToggleSprintEvent(player, true));
 

--- a/src/test/java/studio/magemonkey/divinity/manager/EntityManagerTest.java
+++ b/src/test/java/studio/magemonkey/divinity/manager/EntityManagerTest.java
@@ -1,0 +1,46 @@
+package studio.magemonkey.divinity.manager;
+
+import org.bukkit.event.player.PlayerToggleSprintEvent;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import studio.magemonkey.divinity.config.EngineCfg;
+import studio.magemonkey.divinity.testutil.MockedTest;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class EntityManagerTest extends MockedTest {
+    private PlayerMock player;
+
+    @BeforeEach
+    void setup() {
+        player = genPlayer("Travja");
+    }
+
+    @AfterEach
+    void resetFlag() {
+        EngineCfg.LEGACY_VANILLA_ENTITY_STATS = false;
+    }
+
+    @Test
+    void entityStatsHandlingAppliesDuplicatorFixerByDefault() {
+        EngineCfg.LEGACY_VANILLA_ENTITY_STATS = false;
+
+        server.getPluginManager().callEvent(new PlayerToggleSprintEvent(player, true));
+
+        assertTrue(EntityManager.isPacketDuplicatorFixed(player),
+                "Duplicator fixer metadata should be applied when legacy vanilla entity stats is disabled");
+    }
+
+    @Test
+    void legacyVanillaEntityStatsSkipsDuplicatorFixer() {
+        EngineCfg.LEGACY_VANILLA_ENTITY_STATS = true;
+
+        server.getPluginManager().callEvent(new PlayerToggleSprintEvent(player, true));
+
+        assertFalse(EntityManager.isPacketDuplicatorFixed(player),
+                "Duplicator fixer metadata should not be applied when legacy vanilla entity stats is enabled");
+    }
+}

--- a/src/test/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListenerTest.java
+++ b/src/test/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListenerTest.java
@@ -3,6 +3,10 @@ package studio.magemonkey.divinity.manager.listener.object;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Trident;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+import org.bukkit.event.entity.EntityDamageEvent.DamageModifier;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
@@ -17,9 +21,14 @@ import studio.magemonkey.divinity.stats.items.attributes.DamageAttribute;
 import studio.magemonkey.divinity.api.event.DivinityDamageEvent;
 import studio.magemonkey.divinity.testutil.MockedTest;
 
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.function.Function;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("deprecation")
 public class VanillaWrapperListenerTest extends MockedTest {
     private PlayerMock damager;
     private PlayerMock target;
@@ -101,6 +110,101 @@ public class VanillaWrapperListenerTest extends MockedTest {
 
             return true;
         });
+    }
+
+    @Test
+    void resistancePreservedInsteadOfBeingZeroedOut() {
+        final double base       = 10D;
+        final double resistance = -2D;
+
+        EntityDamageByEntityEvent event = buildDamageEvent(base, resistance, null);
+
+        assertEquals(resistance,
+                event.getDamage(DamageModifier.RESISTANCE),
+                0.001,
+                "Resistance modifier should be preserved rather than zeroed out");
+        assertEquals(base + resistance,
+                event.getFinalDamage(),
+                0.001,
+                "Final damage should reflect the resistance reduction");
+    }
+
+    @Test
+    void absorptionCappedToVictimsAvailableAmountWhenHitIsLarger() {
+        target.setAbsorptionAmount(4D); // 2 golden hearts
+        final double base = 10D;
+
+        EntityDamageByEntityEvent event = buildDamageEvent(base, null, -10D);
+
+        assertEquals(base,
+                event.getDamage(DamageModifier.BASE),
+                0.001,
+                "Base damage should be left untouched; absorption should not also be subtracted from it");
+        assertEquals(-4D,
+                event.getDamage(DamageModifier.ABSORPTION),
+                0.001,
+                "Absorption modifier should be capped to the victim's available absorption amount");
+        assertEquals(6D, event.getFinalDamage(), 0.001, "Absorption should only reduce final damage once");
+    }
+
+    @Test
+    void absorptionNotConsumedBeyondTheIncomingDamage() {
+        target.setAbsorptionAmount(20D); // 10 golden hearts
+        final double base = 2D;
+
+        EntityDamageByEntityEvent event = buildDamageEvent(base, null, -20D);
+
+        assertEquals(-2D,
+                event.getDamage(DamageModifier.ABSORPTION),
+                0.001,
+                "A small hit should only consume absorption equal to its own damage, not drain the whole pool");
+        assertEquals(0D, event.getFinalDamage(), 0.001);
+    }
+
+    @Test
+    void resistanceIsFactoredInBeforeAbsorptionIsCalculated() {
+        target.setAbsorptionAmount(4D); // 2 golden hearts
+        final double base       = 10D;
+        final double resistance = -4D;
+
+        EntityDamageByEntityEvent event = buildDamageEvent(base, resistance, -10D);
+
+        assertEquals(resistance, event.getDamage(DamageModifier.RESISTANCE), 0.001);
+        assertEquals(-4D,
+                event.getDamage(DamageModifier.ABSORPTION),
+                0.001,
+                "Absorption should be computed off the damage remaining after resistance, then capped");
+        assertEquals(base + resistance - 4D, event.getFinalDamage(), 0.001);
+    }
+
+    /**
+     * Fires an {@link EntityDamageByEntityEvent} carrying only the given modifiers (mirroring how the
+     * vanilla server would populate them before Divinity's listener runs), so the resistance/absorption
+     * fix in {@code VanillaWrapperListener#onVanillaDamage} can be exercised in isolation.
+     */
+    private EntityDamageByEntityEvent buildDamageEvent(double base, Double resistance, Double absorption) {
+        Map<DamageModifier, Double> modifiers = new EnumMap<>(DamageModifier.class);
+        Map<DamageModifier, Function<? super Double, Double>> functions = new EnumMap<>(DamageModifier.class);
+
+        modifiers.put(DamageModifier.BASE, base);
+        functions.put(DamageModifier.BASE, d -> base);
+
+        if (resistance != null) {
+            modifiers.put(DamageModifier.RESISTANCE, resistance);
+            functions.put(DamageModifier.RESISTANCE, d -> resistance);
+        }
+        if (absorption != null) {
+            modifiers.put(DamageModifier.ABSORPTION, absorption);
+            functions.put(DamageModifier.ABSORPTION, d -> absorption);
+        }
+
+        EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(damager,
+                target,
+                DamageCause.ENTITY_ATTACK,
+                modifiers,
+                functions);
+        server.getPluginManager().callEvent(event);
+        return event;
     }
 
     private double getTotalDamage(Start event) {

--- a/src/test/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListenerTest.java
+++ b/src/test/java/studio/magemonkey/divinity/manager/listener/object/VanillaWrapperListenerTest.java
@@ -21,9 +21,10 @@ import studio.magemonkey.divinity.stats.items.attributes.DamageAttribute;
 import studio.magemonkey.divinity.api.event.DivinityDamageEvent;
 import studio.magemonkey.divinity.testutil.MockedTest;
 
+import com.google.common.base.Function;
+
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/studio/magemonkey/divinity/stats/items/ItemStatsTest.java
+++ b/src/test/java/studio/magemonkey/divinity/stats/items/ItemStatsTest.java
@@ -1,0 +1,40 @@
+package studio.magemonkey.divinity.stats.items;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockbukkit.mockbukkit.entity.PlayerMock;
+import studio.magemonkey.divinity.config.EngineCfg;
+import studio.magemonkey.divinity.testutil.MockedTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ItemStatsTest extends MockedTest {
+    private PlayerMock player;
+
+    @BeforeEach
+    void setup() {
+        player = genPlayer("Travja");
+    }
+
+    @AfterEach
+    void resetFlag() {
+        EngineCfg.LEGACY_VANILLA_ITEM_STATS = false;
+    }
+
+    @Test
+    void legacyVanillaItemStatsLeavesItemCompletelyUntouched() {
+        EngineCfg.LEGACY_VANILLA_ITEM_STATS = true;
+
+        ItemStack item   = new ItemStack(Material.DIAMOND_SWORD);
+        ItemStack before = item.clone();
+
+        ItemStats.updateVanillaAttributes(item, player);
+
+        assertEquals(before,
+                item,
+                "Item should not be modified at all while legacy vanilla item stats is enabled");
+    }
+}

--- a/src/test/java/studio/magemonkey/divinity/stats/items/ItemStatsTest.java
+++ b/src/test/java/studio/magemonkey/divinity/stats/items/ItemStatsTest.java
@@ -21,12 +21,12 @@ class ItemStatsTest extends MockedTest {
 
     @AfterEach
     void resetFlag() {
-        EngineCfg.LEGACY_VANILLA_ITEM_STATS = false;
+        EngineCfg.VANILLA_ONLY_ITEM_STATS = false;
     }
 
     @Test
     void legacyVanillaItemStatsLeavesItemCompletelyUntouched() {
-        EngineCfg.LEGACY_VANILLA_ITEM_STATS = true;
+        EngineCfg.VANILLA_ONLY_ITEM_STATS = true;
 
         ItemStack item   = new ItemStack(Material.DIAMOND_SWORD);
         ItemStack before = item.clone();


### PR DESCRIPTION
Adds some old fixes (https://github.com/magemonkeystudio/divinity/commit/00d677f003bab2b7d1c9f67beca02b67dc80fe40#diff-9f550a722a805c537319b09760b23aafc9e8f5de24308c96d4438a3baf610c13) for pretty vanilla related servers:
engine.yml
```yaml
[...]
attributes:
  hide-flags: true # Rather custom items will automatically be hidden on all flags. Default behavior is true
[...]
legacy:
  vanilla-entity-stats: false # Makes sure that stats dont affect entities, default is keep the current behavior
  vanilla-item-stats: false # Makes sure that stats dont affect item, default is keep the current behavior
```

### Further things:
- Fixes resistance and absorption behaviour
  - Resistance was completly ignored
  - Absorption was like... drained from the user within a second (even 20 hearts)